### PR TITLE
Only display categories that contain a nonzero amount of visible problems

### DIFF
--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -396,7 +396,9 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
         context['show_types'] = 0 if self.in_contest else int(self.show_types)
         context['full_text'] = 0 if self.in_contest else int(self.full_text)
         context['category'] = self.category
-        context['categories'] = ProblemGroup.objects.all()
+        context['categories'] = (
+            ProblemGroup.objects.filter(problem__in=Problem.get_visible_problems(self.request.user)).distinct()
+        )
         if self.show_types:
             context['selected_types'] = self.selected_types
             context['problem_types'] = ProblemType.objects.all()


### PR DESCRIPTION
Fixes #10.

Note that there are more efficient ways to query categories that have a nonzero amount of visible problems, but they require template changes. This approach should be fine for <= 5000 problems.